### PR TITLE
Use true_type and false_type to split save/load

### DIFF
--- a/include/ten/jserial.hh
+++ b/include/ten/jserial.hh
@@ -38,9 +38,9 @@ class JSave {
     save_mode _mode;
 
   public:
-    static const bool is_archive = true;
-    static const bool is_save = true;
-    static const bool is_load = false;
+    using is_archive = std::true_type;
+    using is_save    = std::true_type;
+    using is_load    = std::false_type;
 
     explicit JSave(unsigned ver = 0, save_mode mode = save_all)
         : _version(ver), _mode(mode) {}
@@ -114,9 +114,9 @@ class JLoad {
     unsigned _version;
 
   public:
-    static const bool is_archive = true;
-    static const bool is_save = false;
-    static const bool is_load = true;
+    using is_archive = std::true_type;
+    using is_save    = std::false_type;
+    using is_load    = std::true_type;
 
     JLoad(const json & j, unsigned ver = 0) : _j(j), _version(ver) {}
     JLoad(      json &&j, unsigned ver = 0) : _j(j), _version(ver) {}

--- a/include/ten/jserial_enum.hh
+++ b/include/ten/jserial_enum.hh
@@ -2,7 +2,8 @@
 #define LIBTEN_JSERIAL_ENUM_HH
 
 #include "ten/jserial.hh"
-#include <array>
+#include <algorithm>
+#include <type_traits>
 
 namespace ten {
 using std::string;
@@ -10,26 +11,33 @@ using std::string;
 // first define an std::array<const char *, N> of enum names
 // then call this as the body of your enum's operator &
 
-template <class AR, class E, size_t NameCount>
-inline AR & serialize_enum(AR &ar, E &e, const std::array<const char *, NameCount> &names) {
-    if (AR::is_save) {
-        // this is a kludge for unified archiving.  constness is a PITA
-        json j(names[(size_t)e]);
-        return ar & j;
-    }
-    else {
-        json j;
-        ar & j;
-        if (j.is_string()) {
-            for (size_t i = 0; i < NameCount; ++i) {
-                if (!strcmp(names[i], j.c_str())) {
-                    e = E(i);
-                    return ar;
-                }
-            }
+namespace detail {
+template <class AR, class E, class Iter>
+inline AR & serialize_enum(AR &ar, E &e, Iter names_start, Iter names_end, std::true_type) {
+    return ar & json::str(*(names_start + (ptrdiff_t)e));
+}
+template <class AR, class E, class Iter>
+inline AR & serialize_enum(AR &ar, E &e, Iter names_start, Iter names_end, std::false_type) {
+    json j;
+    ar & j;
+    if (j.is_string()) {
+        auto nit = std::find(names_start, names_end, j.str());
+        if (nit != names_end) {
+            e = E(nit - names_start);
+            return ar;
         }
-        throw errorx("invalid %s: %s", typeid(E).name(), j.dump().c_str());
     }
+    throw errorx("invalid %s: %s", typeid(E).name(), j.dump().c_str());
+}
+} // detail
+
+template <class AR, class E, class Iter>
+inline AR & serialize_enum(AR &ar, E &e, Iter names_start, Iter names_end) {
+    return detail::serialize_enum(ar, e, names_start, names_end, typename AR::is_save());
+}
+template <class AR, class E, class Coll>
+inline AR & serialize_enum(AR &ar, E &e, const Coll &c) {
+    return detail::serialize_enum(ar, e, c.begin(), c.end(), typename AR::is_save());
 }
 
 } // ten

--- a/tests/test_json.cc
+++ b/tests/test_json.cc
@@ -6,6 +6,7 @@
 #include <ten/jserial_seq.hh>
 #include <ten/jserial_assoc.hh>
 #include <ten/jserial_enum.hh>
+#include <array>
 
 using namespace std;
 using namespace ten;
@@ -214,7 +215,7 @@ inline bool operator == (const corge &a, const corge &b) {
 
 
 enum captain { kirk, picard, janeway, sisko };
-constexpr array<const char *, 4> captain_names = {{ "kirk", "picard", "janeway", "sisko" }};
+const array<string, 4> captain_names = {{ "kirk", "picard", "janeway", "sisko" }};
 template <class AR>
 inline AR & operator & (AR &ar, captain &c) {
     return serialize_enum(ar, c, captain_names);


### PR DESCRIPTION
Use true_type and false_type to split save/load for enum and maybe<>.
Ease the above by making Archive::is_\* types, not booleans.
Generalize enum more, perhaps unnecessarily; any sequential collection will
  do now (but now it makes a string copy, ah well).
