### PR TITLE
format option diagnostics for terminal width

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(ten
     src/net.cc
     src/zip.cc
     src/json.cc
+    src/term.cc
     ${ASM}
     ${RESOLVER_SRC}
     ${SSL_SRC}

--- a/include/ten/app.hh
+++ b/include/ten/app.hh
@@ -1,5 +1,5 @@
-#ifndef APP_HH
-#define APP_HH
+#ifndef LIBTEN_APP_HH
+#define LIBTEN_APP_HH
 
 #include <sys/resource.h>
 #include <iostream>
@@ -10,6 +10,7 @@
 
 #include "task.hh"
 #include "logging.hh"
+#include "term.hh"
 #include "descriptors.hh"
 
 namespace ten {
@@ -59,20 +60,25 @@ namespace po = boost::program_options;
 
 //! setup basic options for all applications
 struct options {
+    const unsigned line_length;
+
     po::options_description generic;
     po::options_description configuration;
     po::options_description hidden;
-    po::positional_options_description pdesc;
-
+    po::options_description visible;
     po::options_description cmdline_options;
     po::options_description config_file_options;
-    po::options_description visible;
+    po::positional_options_description pdesc;
 
     options(const char *appname, app_config &c) :
-        generic("Generic options"),
-        configuration("Configuration"),
-        hidden("Hidden options"),
-        visible("Allowed options")
+        line_length(terminal_width()),
+        generic("Generic options",     line_length, line_length / 2),
+        configuration("Configuration", line_length, line_length / 2),
+        hidden("Hidden options",       line_length, line_length / 2),
+        visible("Allowed options",     line_length, line_length / 2),
+        cmdline_options(    line_length, line_length / 2),
+        config_file_options(line_length, line_length / 2),
+        pdesc()
     {
         generic.add_options()
             ("version,v", "Show version")

--- a/include/ten/term.hh
+++ b/include/ten/term.hh
@@ -1,0 +1,10 @@
+#ifndef LIBTEN_TERM_HH
+#define LIBTEN_TERM_HH
+
+namespace ten {
+
+unsigned terminal_width();
+
+} // ten
+
+#endif // LIBTEN_TERM_HH

--- a/src/term.cc
+++ b/src/term.cc
@@ -1,0 +1,15 @@
+#include "ten/term.hh"
+#include <sys/ioctl.h>
+
+namespace ten {
+
+unsigned terminal_width() {
+#ifdef TIOCGWINSZ
+    winsize sz;
+    if (ioctl(2, TIOCGWINSZ, &sz) == 0 && sz.ws_col)
+        return sz.ws_col;
+#endif
+    return 80;
+}
+
+} // ten


### PR DESCRIPTION
our terminals aren't 80-wide any more.  Really this should be in program::options, but fo rnow, it's here.
