### PR TITLE
Make http_status_t an enum.

### DIFF
--- a/examples/http-proxy.cc
+++ b/examples/http-proxy.cc
@@ -24,8 +24,8 @@ void sock_copy(channel<int> c, netsock &a, netsock &b, buffer &buf) {
     c.send(1);
 }
 
-void send_503_reply(netsock &s) {
-    http_response resp{503};
+void send_unavail_reply(netsock &s) {
+    http_response resp{ HTTP_Service_Unavailable };
     std::string data = resp.data();
     ssize_t nw = s.send(data.data(), data.size());
     (void)nw; // ignore
@@ -152,7 +152,7 @@ void proxy_task(int sock) {
         }
     } catch (errno_error &e) {
         PLOG(ERROR) << "request connect error " << req.method << " " << req.uri;
-        send_503_reply(s);
+        send_unavail_reply(s);
         return;
     } catch (std::exception &e) {
         LOG(ERROR) << "exception error: " << req.uri << " : " << e.what();
@@ -163,11 +163,11 @@ request_read_error:
     return;
 request_send_error:
     PLOG(ERROR) << "request send error: " << req.method << " " << req.uri;
-    send_503_reply(s);
+    send_unavail_reply(s);
     return;
 response_read_error:
     PLOG(ERROR) << "response read error: " << req.method << " " << req.uri;
-    send_503_reply(s);
+    send_unavail_reply(s);
     return;
 response_send_error:
     PLOG(ERROR) << "response send error: " << req.method << " " << req.uri;

--- a/examples/http-server.cc
+++ b/examples/http-server.cc
@@ -46,13 +46,13 @@ static void http_quit(std::weak_ptr<state> wst, http_exchange &ex) {
         LOG(INFO) << "quit requested over http";
         st->app->quit();
     }
-    ex.resp = { 200, { "Connection", "close" } };
+    ex.resp = { HTTP_OK, { "Connection", "close" } };
     ex.resp.set_body("");
     ex.send_response();
 }
 
 static void http_root(std::weak_ptr<state> wst, http_exchange &ex) {
-    ex.resp = { 200 };
+    ex.resp = { HTTP_OK };
     ex.resp.set_body("Hello World!\n", "text/plain");
     ex.send_response();
 }

--- a/include/ten/http/client.hh
+++ b/include/ten/http/client.hh
@@ -117,8 +117,6 @@ public:
         try {
             ensure_connection();
 
-            http_response resp(&r);
-
             std::string data = r.data();
             if (r.body.size() > 0) {
                 data += r.body;
@@ -133,8 +131,9 @@ public:
                 throw http_error(ss.str().c_str());
             }
 
+            http_response resp;
             http_parser parser;
-            resp.parser_init(&parser);
+            resp.parser_init(&parser, r.method == hs::HEAD);
 
             _buf.clear();
 

--- a/tests/test_buffer.cc
+++ b/tests/test_buffer.cc
@@ -13,14 +13,14 @@ TEST(Buffer, Test1) {
     EXPECT_TRUE(b.end() - b.back() >= 1000);
     std::fill(b.back(), b.end(1000), 0x41);
     b.commit(1000);
-    EXPECT_EQ(1000, b.size());
+    EXPECT_EQ(1000u, b.size());
     b.remove(500);
     b.reserve(1000);
     EXPECT_TRUE(b.end() - b.back() >= 1000);
     EXPECT_TRUE(std::equal(b.front(), b.back(), aa.begin()));
     std::fill(b.front(), b.end(500), 0x42);
     b.commit(500);
-    EXPECT_EQ(1000, b.size());
+    EXPECT_EQ(1000u, b.size());
     EXPECT_TRUE(std::equal(b.front(), b.back(), bb.begin()));
     b.remove(500);
     b.reserve(1000);

--- a/tests/test_descriptors.cc
+++ b/tests/test_descriptors.cc
@@ -75,9 +75,9 @@ TEST(DescriptorTest, signal_fd_test) {
 TEST(DescriptorTest, event_fd_test) {
     event_fd efd;
     efd.write(1);
-    EXPECT_EQ(efd.read(), 1);
+    EXPECT_EQ(efd.read(), 1u);
     efd.write(1);
     efd.write(2);
     efd.write(3);
-    EXPECT_EQ(efd.read(), 1+2+3);
+    EXPECT_EQ(efd.read(), (unsigned)(1+2+3));
 }

--- a/tests/test_hash_ring.cc
+++ b/tests/test_hash_ring.cc
@@ -61,7 +61,7 @@ TEST(HashRing, Basic) {
     }
 
     // remove a server
-    EXPECT_EQ(3, ring.remove("server3.example.com"));
+    EXPECT_EQ(3u, ring.remove("server3.example.com"));
 
     unsigned found = 0;
     for (auto it : data) {
@@ -82,8 +82,8 @@ TEST(HashRing, Remove) {
     ring.add("test1");
     ring.add("test2");
     ring.add("test3");
-    EXPECT_EQ(100, ring.remove("test1"));
-    EXPECT_EQ(100, ring.remove("test3"));
-    EXPECT_EQ(100, ring.remove("test2"));
+    EXPECT_EQ(100u, ring.remove("test1"));
+    EXPECT_EQ(100u, ring.remove("test3"));
+    EXPECT_EQ(100u, ring.remove("test2"));
 }
 

--- a/tests/test_http.cc
+++ b/tests/test_http.cc
@@ -6,20 +6,16 @@
 using namespace ten;
 
 // make sure static init works, this will crash if we break it
-static const http_response test_static_init(200,
-        http_headers("Access-Control-Allow-Origin", "*")
-        );
+static const http_response test_static_init{ HTTP_OK, { "Access-Control-Allow-Origin", "*" } };
 
 TEST(Http, HeadersVariadicTemplate) {
-    http_request req{hs::GET, "/foo",
-        http_headers{"This", 4, "That", "that"}
-    };
+    http_request req{hs::GET, "/foo", {"This", 4, "That", "that"}};
     ASSERT_TRUE((bool)req.get<int>("this"));
     EXPECT_EQ(4, *req.get<int>("this"));
     ASSERT_TRUE((bool)req.get("that"));
     EXPECT_EQ("that", *req.get("that"));
 
-    http_response resp{200, http_headers{"Thing", "stuff"}};
+    http_response resp{HTTP_OK, {"Thing", "stuff"}};
     ASSERT_TRUE((bool)resp.get("thing"));
     EXPECT_EQ("stuff", *resp.get("thing"));
 }
@@ -33,7 +29,7 @@ TEST(Http, RequestConstructor) {
     EXPECT_EQ("/corge", req2.uri);
     EXPECT_EQ(default_http_version, req2.version);
     EXPECT_EQ("text/json", *req2.get("Content-Type"));
-    EXPECT_EQ(3, *req2.get<uint64_t>("Content-Length"));
+    EXPECT_EQ(3u, *req2.get<uint64_t>("Content-Length"));
     EXPECT_EQ("[1]", req2.body);
 }
 
@@ -121,7 +117,7 @@ TEST(Http, RequestParserNormalizeHeaderNames) {
     EXPECT_EQ("/test/this?thing=1&stuff=2&fun&good", req.uri);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -150,7 +146,7 @@ TEST(Http, RequestParserHeaders) {
     EXPECT_EQ(hs::GET, req.method);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -174,7 +170,7 @@ TEST(Http, RequestParserUnicodeEscape) {
     EXPECT_EQ(hs::GET, req.method);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -198,7 +194,7 @@ TEST(Http, RequestParserPercents) {
     EXPECT_EQ(hs::GET, req.method);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -224,7 +220,7 @@ TEST(Http, RequestParserBadPercents) {
     EXPECT_EQ(hs::GET, req.method);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -249,7 +245,7 @@ TEST(Http, RequestParserHeaderParts) {
     EXPECT_EQ("/test/this?thing=1&stuff=2&fun&good", req.uri);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -271,7 +267,7 @@ TEST(Http, RequestParserNoHeaders) {
     EXPECT_EQ("/test/this?thing=1&stuff=2&fun&good", req.uri);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
 }
 
 TEST(Http, RequestParserGarbage) {
@@ -302,7 +298,7 @@ TEST(Http, RequestParserProxyHttp12) {
     EXPECT_EQ("http://example.com:9182/test/this?thing=1&stuff=2&fun&good", req.uri);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -327,7 +323,7 @@ TEST(Http, RequestClear) {
     EXPECT_EQ("/test/this?thing=1&stuff=2&fun&good", req.uri);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -339,7 +335,7 @@ TEST(Http, RequestClear) {
     EXPECT_TRUE(req.uri.empty());
     EXPECT_EQ(req.version, default_http_version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
 
     req.parser_init(&parser);
     len = strlen(sdata);
@@ -350,7 +346,7 @@ TEST(Http, RequestClear) {
     EXPECT_EQ("/test/this?thing=1&stuff=2&fun&good", req.uri);
     EXPECT_EQ(http_1_1, req.version);
     EXPECT_TRUE(req.body.empty());
-    EXPECT_EQ(0, req.body_length);
+    EXPECT_EQ(0u, req.body_length);
     EXPECT_EQ("curl/7.21.0 (i686-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18",
         *req.get("User-Agent"));
     EXPECT_EQ("localhost:8080", *req.get("Host"));
@@ -389,26 +385,26 @@ TEST(Http, RequestHostWithUnderscores) {
 
 TEST(Http, ResponseConstructor) {
     http_response resp;
-    EXPECT_EQ(200, resp.status_code);
+    EXPECT_EQ(HTTP_OK, resp.status_code);
     EXPECT_EQ("OK", resp.reason());
     EXPECT_EQ(default_http_version, resp.version);
     EXPECT_TRUE(resp.body.empty());
 
-    http_response resp2{200, {"Foo", "bar"}, "[1]", std::string{"text/json"}};
-    EXPECT_EQ(200, resp2.status_code);
+    http_response resp2{HTTP_OK, {"Foo", "bar"}, "[1]", "text/json"};
+    EXPECT_EQ(HTTP_OK, resp2.status_code);
     EXPECT_EQ("OK", resp2.reason());
     EXPECT_EQ(default_http_version, resp2.version);
     EXPECT_EQ("text/json", *resp2.get("Content-Type"));
-    EXPECT_EQ(3, *resp2.get<uint64_t>("Content-Length"));
+    EXPECT_EQ(3u, *resp2.get<uint64_t>("Content-Length"));
     EXPECT_EQ("[1]", resp2.body);
 }
 
 TEST(Http, ResponseData) {
-    http_response resp{200};
+    http_response resp{HTTP_OK};
     resp.append("Host", "localhost");
     resp.append("Content-Length", "0");
 
-    EXPECT_EQ(200, resp.status_code);
+    EXPECT_EQ(HTTP_OK, resp.status_code);
     EXPECT_EQ("OK", resp.reason());
     EXPECT_EQ(http_1_1, resp.version);
     EXPECT_EQ("0", *resp.get("content-length"));
@@ -423,7 +419,7 @@ TEST(Http, ResponseData) {
 }
 
 TEST(Http, ResponseBody) {
-    http_response resp{200};
+    http_response resp{HTTP_OK};
 
     resp.append("Host", "localhost");
 
@@ -431,7 +427,7 @@ TEST(Http, ResponseBody) {
 
     resp.set_body(body, "text/plain");
 
-    EXPECT_EQ(200, resp.status_code);
+    EXPECT_EQ(HTTP_OK, resp.status_code);
     EXPECT_EQ("OK", resp.reason());
     EXPECT_EQ(http_1_1, resp.version);
     EXPECT_EQ("37", *resp.get("content-length"));
@@ -454,7 +450,34 @@ TEST(Http, ResponseParserInit) {
 
     resp.parser_init(&parser);
     EXPECT_TRUE(resp.body.empty());
+    EXPECT_EQ(0u, resp.body_length);
     EXPECT_EQ(parser.data, &resp);
+}
+
+TEST(Http, ResponseParserGuillotine) {
+    static const char *sdata =
+    "HTTP/1.1 200 OK\r\n"
+    "Host: localhost\r\n"
+    "Content-Length: 37\r\n"
+    "Content-Type: text/plain\r\n"
+    "\r\n"
+    "this is a test.\r\nthis is only a test.";
+
+    http_response resp;
+    http_parser parser;
+
+    resp.parser_init(&parser, true);
+    size_t len = strlen(sdata);
+    resp.parse(&parser, sdata, len);
+    EXPECT_TRUE(resp.complete);
+
+    EXPECT_EQ(HTTP_OK, resp.status_code);
+    EXPECT_EQ("OK", resp.reason());
+    EXPECT_EQ(http_1_1, resp.version);
+    EXPECT_EQ(37u, *resp.get<uint64_t>("content-length"));
+    EXPECT_EQ("text/plain", *resp.get("content-type"));
+    EXPECT_TRUE(resp.body.empty());
+    EXPECT_EQ(0u, resp.body_length);
 }
 
 TEST(Http, ResponseParserOneByte) {
@@ -481,14 +504,14 @@ TEST(Http, ResponseParserOneByte) {
     EXPECT_TRUE(resp.complete);
     VLOG(1) << "Response:\n" << resp.data() << resp.body;
 
-    EXPECT_EQ(200, resp.status_code);
+    EXPECT_EQ(HTTP_OK, resp.status_code);
     EXPECT_EQ("OK", resp.reason());
     EXPECT_EQ(http_1_1, resp.version);
     EXPECT_EQ("37", *resp.get("content-length"));
-    EXPECT_EQ(37, *resp.get<uint64_t>("content-length"));
+    EXPECT_EQ(37u, *resp.get<uint64_t>("content-length"));
     EXPECT_EQ("text/plain", *resp.get("content-type"));
     EXPECT_EQ("this is a test.\r\nthis is only a test.", resp.body);
-    EXPECT_EQ(37, resp.body_length);
+    EXPECT_EQ(37u, resp.body_length);
 }
 
 TEST(Http, ResponseParserNormalizeHeaderNames) {
@@ -507,14 +530,14 @@ TEST(Http, ResponseParserNormalizeHeaderNames) {
     resp.parse(&parser, sdata, len);
     EXPECT_TRUE(resp.complete);
 
-    EXPECT_EQ(200, resp.status_code);
+    EXPECT_EQ(HTTP_OK, resp.status_code);
     EXPECT_EQ("OK", resp.reason());
     EXPECT_EQ(http_1_1, resp.version);
     EXPECT_EQ("37", *resp.get("content-length"));
-    EXPECT_EQ(37, *resp.get<uint64_t>("content-length"));
+    EXPECT_EQ(37u, *resp.get<uint64_t>("content-length"));
     EXPECT_EQ("text/plain", *resp.get("content-type"));
     EXPECT_EQ("this is a test.\r\nthis is only a test.", resp.body);
-    EXPECT_EQ(37, resp.body_length);
+    EXPECT_EQ(37u, resp.body_length);
 }
 
 TEST(Http, ResponseParserChunked) {
@@ -543,12 +566,12 @@ TEST(Http, ResponseParserChunked) {
     EXPECT_TRUE(resp.complete);
     VLOG(1) << "Response:\n" << resp.data() << resp.body;
 
-    EXPECT_EQ(200, resp.status_code);
+    EXPECT_EQ(HTTP_OK, resp.status_code);
     EXPECT_EQ("OK", resp.reason());
     EXPECT_EQ(http_1_1, resp.version);
     EXPECT_EQ("text/plain", *resp.get("Content-Type"));
     EXPECT_EQ("chunked", *resp.get("Transfer-Encoding"));
-    EXPECT_EQ(resp.body_length, 76);
+    EXPECT_EQ(76u, resp.body_length);
 }
 
 TEST(Http, BenchAsciiIequals) {

--- a/tests/test_json.cc
+++ b/tests/test_json.cc
@@ -114,7 +114,7 @@ TEST(Json, FilterKeyExists) {
 
     json r1{o.path("//book[doesnotexist]")};
     ASSERT_TRUE(r1.is_array());
-    EXPECT_EQ(0, r1.asize());
+    EXPECT_EQ(0u, r1.asize());
 }
 
 TEST(Json, Truth) {
@@ -153,7 +153,7 @@ TEST(Json, InitList) {
     };
     ASSERT_TRUE((bool)meta);
     ASSERT_TRUE(meta.is_object());
-    EXPECT_EQ(meta.osize(), 5);
+    EXPECT_EQ(meta.osize(), 5u);
     EXPECT_EQ(meta["foo"].integer(), 17);
     EXPECT_EQ(meta["corge"][0].integer(), 1);
     EXPECT_EQ(meta["grault"][1].str(), "world");

--- a/tests/test_net.cc
+++ b/tests/test_net.cc
@@ -28,16 +28,16 @@ TEST(Net, SocketDial) {
 }
 
 static void http_callback(http_exchange &ex) {
-    ex.resp = { 200, {}, "Hello World" };
+    ex.resp = { HTTP_OK, {}, "Hello World" };
 }
 
 static void http_post_callback(http_exchange &ex) {
-    ex.resp = { 200, {}, "Post World" };
+    ex.resp = { HTTP_OK, {}, "Post World" };
 }
 
 static void http_slow_callback(http_exchange &ex) {
     this_task::sleep_for(milliseconds{10});
-    ex.resp = { 200, {}, "Slow World" };
+    ex.resp = { HTTP_OK, {}, "Slow World" };
 }
 
 static void start_http_server(address &addr) {
@@ -72,9 +72,9 @@ static void start_http_test() {
             deadline dl{milliseconds{5}};
             resp = c.get("/slow");
         } catch (deadline_reached) {
-            resp = { 408 };
+            resp = { HTTP_Request_Timeout };
         }
-        EXPECT_EQ(408, resp.status_code);
+        EXPECT_EQ(HTTP_Request_Timeout, resp.status_code);
     }
 
     server_task.cancel();
@@ -86,9 +86,9 @@ static void start_http_test() {
         try {
             resp = c.get("/blargh");
         } catch (http_dial_error &e) {
-            resp = { 503 };
+            resp = { HTTP_Service_Unavailable };
         }
-        EXPECT_EQ(resp.status_code, 503); // connect refused -> 503
+        EXPECT_EQ(resp.status_code, HTTP_Service_Unavailable); // connect refused -> 503
     }
 }
 

--- a/tests/test_task.cc
+++ b/tests/test_task.cc
@@ -67,7 +67,7 @@ TEST(Task, Fdwait) {
     task::main([&] {
         task::spawn([&] { pipe_wait(bytes); });
     });
-    EXPECT_EQ(bytes, 4);
+    EXPECT_EQ(bytes, 4u);
 }
 
 static void connect_to(address addr) {
@@ -183,7 +183,7 @@ TEST(Task, ManyTimeouts) {
             });
         }
     });
-    EXPECT_EQ(count, 3000);
+    EXPECT_EQ(count, 3000u);
 }
 
 static void long_sleeper() {
@@ -281,7 +281,7 @@ static void yield_timer() {
     // tight yield loop should take less than microsecond
     // this test depends on hardware and will probably fail
     // when run under debugging tools like valgrind/gdb
-    EXPECT_GT(counter, 100000);
+    EXPECT_GT(counter, 100000u);
 }
 
 TEST(Task, YieldTimer) {

--- a/tests/test_uri.cc
+++ b/tests/test_uri.cc
@@ -73,7 +73,7 @@ TEST(Uri, ParseQuery) {
     u.normalize();
     uri::query_params params = u.query_part();
     // NOTE: the string below should appear as russian
-    EXPECT_EQ(params.size(), 1);
+    EXPECT_EQ(params.size(), 1u);
     EXPECT_EQ(params.find("q")->second, "путин");
 }
 


### PR DESCRIPTION
Make http_status_t an enum.

Also:
Fix signed-vs-unsigned warnings in self tests.
In support of HEAD requests, replace obsolescent http_response constructor
  in favor of an explicit parser_init() parameter, and test it.
